### PR TITLE
26 create availability test sucess

### DIFF
--- a/src/main/java/health/care/booking/controllers/AvailabilityController.java
+++ b/src/main/java/health/care/booking/controllers/AvailabilityController.java
@@ -31,8 +31,8 @@ public class AvailabilityController {
 
     // OBS create error handling for unorthorized attempts to create availability
     // and check that entered availability is not already excisting! OBS
-    public ResponseEntity<Availability> createAvailability(@RequestParam String caregiverId, @RequestBody List<LocalDateTime> availabilitySlots){
-        Availability availability = availabilityService.createAvailability(caregiverId, availabilitySlots);
+    public ResponseEntity<Availability> createAvailability(@RequestParam String caregiverId, @RequestBody List<LocalDateTime> availableSlots){
+        Availability availability = availabilityService.createAvailability(caregiverId, availableSlots);
         return ResponseEntity.ok(availability);
     }
     //preAuthorized? för att se om user är ADMIN?

--- a/src/main/java/health/care/booking/services/AvailabilityService.java
+++ b/src/main/java/health/care/booking/services/AvailabilityService.java
@@ -27,14 +27,14 @@ public class AvailabilityService {
 
     // OBS create error handling for unorthorized attempts to create availability
     // and check that entered availability is not already excisting! OBS
-    public Availability createAvailability (String caregiverId, List<LocalDateTime> availabilitySlots) {
+    public Availability createAvailability (String caregiverId, List<LocalDateTime> availableSlots) {
 
         User caregiver = userRepository.findById(caregiverId)
                 .orElseThrow(() -> new IllegalArgumentException("Caregiver with ID " + caregiverId + " not found"));
 
         Availability availability = new Availability();
         availability.setCaregiverId(caregiver);
-        availability.setAvailableSlots(availabilitySlots);
+        availability.setAvailableSlots(availableSlots);
 
         return availabilityRepository.save(availability);
 

--- a/src/test/java/health/care/booking/AvailabilityServiceTests.java
+++ b/src/test/java/health/care/booking/AvailabilityServiceTests.java
@@ -1,4 +1,101 @@
 package health.care.booking;
 
+import health.care.booking.models.Availability;
+import health.care.booking.models.User;
+import health.care.booking.respository.AvailabilityRepository;
+import health.care.booking.respository.UserRepository;
+import health.care.booking.services.AvailabilityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 public class AvailabilityServiceTests {
+    //mocka repository
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AvailabilityRepository availabilityRepository;
+
+    @InjectMocks
+    private AvailabilityService availabilityService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * test createAvailability method to ensure that availabilty is created correct
+     * */
+    @Test
+    public void testCreateAvailability_Success() {
+        // arrange
+        // create sample availability data for user and availabilitySlots
+
+        // example caregiverId
+        String caregiverId = "12345";
+        // mock availableSlots
+        List<LocalDateTime> availableSlots = Arrays.asList(
+                LocalDateTime.of(2025,1,13,10,0),
+                LocalDateTime.of(2025,1,13,13,0)
+        );
+
+        // creating a mock caregiver as a User object
+        User mockCareGiver = new User();
+        mockCareGiver.setId(caregiverId);
+
+        // creating a mock availability object
+        Availability mockAvailability = new Availability();
+        mockAvailability.setCaregiverId(mockCareGiver);
+        mockAvailability.setAvailableSlots(availableSlots);
+
+        // mocking the behavior of userRepository.findById and return a mock caregiver
+        when(userRepository.findById(caregiverId)).thenReturn(Optional.of(mockCareGiver));
+        // mocking the behavior of availabilityRepository.save and return the mock availability
+        when(availabilityRepository.save(any(Availability.class))).thenReturn(mockAvailability);
+
+
+        // act
+        // calling the method during test
+        Availability result = availabilityService.createAvailability(caregiverId, availableSlots);
+
+        // assert
+        // verify the results
+        // check that the result is not null
+        assertNotNull(result);
+        // check that caregiverId has a match
+        assertEquals(caregiverId, result.getCaregiverId().getId());
+        // check that availableSlots match
+        assertEquals(availableSlots, result.getAvailableSlots());
+
+        // verify that the findById method is called just one time with correct caregiverId
+        verify(userRepository, times(1)).findById(caregiverId);
+        // verify that the save method is called just one time with any availability object
+        verify(availabilityRepository, times(1)).save(any(Availability.class));
+    }
+
+
+
+
+
+
+
+
+
+
+
+
 }
+

--- a/src/test/java/health/care/booking/AvailabilityServiceTests.java
+++ b/src/test/java/health/care/booking/AvailabilityServiceTests.java
@@ -16,8 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -86,6 +85,36 @@ public class AvailabilityServiceTests {
         verify(availabilityRepository, times(1)).save(any(Availability.class));
     }
 
+    @Test
+    public void testCreateAvailability_CaregiverNotFound() {
+        // arrange
+        // setting up test data
+
+        //non-existing caregiverId
+        String caregiverId = "nonexistent";
+        List<LocalDateTime> availableSlots = Arrays.asList(
+                LocalDateTime.of(2025,1,13,10,0),
+                LocalDateTime.of(2025,1,13,13,0)
+        );
+        // mock the behavior of userRepository.findById to return an empty Optional
+        when(userRepository.findById(caregiverId)).thenReturn(Optional.empty());
+
+        // act & assert
+        // verify that an exception is thrown
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                // calls the method
+                availabilityService.createAvailability(caregiverId, availableSlots)
+        );
+
+        // check exception message
+        assertEquals("Caregiver with ID nonexistent not found", exception.getMessage());
+
+        // verify that the findById method only gets called one time
+        verify(userRepository, times(1)).findById(caregiverId);
+
+        // verify that the save method in availability repository never gets called
+        verifyNoInteractions(availabilityRepository);
+    }
 
 
 

--- a/src/test/java/health/care/booking/AvailabilityServiceTests.java
+++ b/src/test/java/health/care/booking/AvailabilityServiceTests.java
@@ -1,0 +1,4 @@
+package health.care.booking;
+
+public class AvailabilityServiceTests {
+}


### PR DESCRIPTION
Test for creating availabillity both success and failing if the caregiverId is not existing.
i had to rename the input in the controller and service on the branch to match the Availability model since i named the List AvailabilitySlots when its called availableSlots in the model, resulting in that the test couldnt find a getter for the list.

checkout development and do a git pull to make sure you have the branch.

checkout 26-create-availability-test-success

open test/java/health.care.booking and open the AvailabilityServisTests file.
klick the start button next to public class AvailabilityServiceTests:
![Screenshot 2025-01-13 at 14 43 14](https://github.com/user-attachments/assets/87dbbc99-57f9-44e3-89df-001dd55e736c)


Both test should run and the output should look like this:
![availability-tests](https://github.com/user-attachments/assets/b382ad10-e5a8-413a-a120-566c6f3124ad)

you can also test one test at a time for good measure :)

here is the promt that i used in chat gpt and double checked with how the tests Helena wrote in her videos to make sure it looked ok!
<img width="625" alt="prompt-screenshot-1" src="https://github.com/user-attachments/assets/08b9b053-72f3-461b-b262-4abe6ec39726" />

Happy testing.