### PR TITLE
Enhanced verification in method addNewTimeSlot

### DIFF
--- a/src/main/java/health/care/booking/respository/AppointmentRepository.java
+++ b/src/main/java/health/care/booking/respository/AppointmentRepository.java
@@ -5,13 +5,14 @@ import health.care.booking.models.User;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AppointmentRepository extends MongoRepository<Appointment, String > {
    Optional<Appointment> findAppointmentById(String appointmentId);
-
+   Appointment findAppointmentByCaregiverIdAndDateTime(User caregiverId, LocalDateTime dateTime);
    List<Appointment> findAllByCaregiverIdOrPatientId(User caregiverId, User patientId);
 
 }

--- a/src/main/java/health/care/booking/services/AppointmentService.java
+++ b/src/main/java/health/care/booking/services/AppointmentService.java
@@ -11,7 +11,9 @@ import health.care.booking.respository.AvailabilityRepository;
 import health.care.booking.respository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -69,6 +71,7 @@ public class AppointmentService {
         if (foundAppointments == null || foundAppointments.isEmpty()) {
             throw new ObjectNotFoundException("No appointments found for user with id: '" + userId + "'");
         } else
-            return foundAppointments;
+            foundAppointments.sort(Comparator.comparing(Appointment::getDateTime));
+        return foundAppointments;
     }
 }

--- a/src/main/java/health/care/booking/services/AvailabilityService.java
+++ b/src/main/java/health/care/booking/services/AvailabilityService.java
@@ -2,8 +2,10 @@ package health.care.booking.services;
 
 
 import health.care.booking.exceptions.ObjectNotFoundException;
+import health.care.booking.models.Appointment;
 import health.care.booking.models.Availability;
 import health.care.booking.models.User;
+import health.care.booking.respository.AppointmentRepository;
 import health.care.booking.respository.AvailabilityRepository;
 import health.care.booking.respository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +22,8 @@ public class AvailabilityService {
     UserRepository userRepository;
     @Autowired
     AvailabilityRepository availabilityRepository;
+    @Autowired
+    AppointmentRepository appointmentRepository;
 
 
 
@@ -100,7 +104,11 @@ public class AvailabilityService {
     // availability with the same date and caregiver
     public void validateCaregiversTimeSlots(String caregiverId, LocalDateTime timeslot) {
         List<Availability> caregiversAvailabilities = availabilityRepository.findAvailabilitiesByCaregiverId(caregiverId);
-
+        User user = userRepository.findUserById(caregiverId);
+        Appointment appointment = appointmentRepository.findAppointmentByCaregiverIdAndDateTime(user, timeslot);
+        if (appointment != null && appointment.getDateTime().equals(timeslot)) {
+            throw new IllegalArgumentException("Time slot already exists in a booked appointment");
+        }
         for (Availability a : caregiversAvailabilities) {
             if (a.getAvailableSlots().contains(timeslot)) {
                 throw new IllegalArgumentException("Time slot already exists");


### PR DESCRIPTION
Created verification that makes sure that the time slot that is requested to be added, does not exists in an appointment.

TESTING
- git checkout 53-create-verification-check-when-adding-new-time-slot-for-booked-appointments
- boot the application
- open postman and do a GET at http://localhost:8080/appointment/all
- Grab a caregiverId and an existing LocalDateTime from an appointment
- Open another tab in postman. PATCH at http://localhost:8080/availability/addtimeslot
- Add the params caregiverId and timeSlot like this: 

![image](https://github.com/user-attachments/assets/0fa571f6-e153-435c-93a7-54961b04c81d)

- Click send and hopefully it will tell you that the time slot already exists in an appointment. 
- Try to send in another timeSlot that already exists in availabilities, and get the proper response
- Try to send in a new timeSlot that does not exists, and see if you get the proper response, and that it appears in the database under the right date